### PR TITLE
Set use_texture_alpha

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -20,6 +20,7 @@ minetest.override_item("flowers:mushroom_red", {
 		"nextgen_fungi_mushroom_red.png",
 		"nextgen_fungi_mushroom_red.png"
 	},
+	use_texture_alpha = "clip",
 	inventory_image = "nextgen_fungi_mushroom_red.png",
 	drawtype = "nodebox",
 	paramtype = "light",
@@ -52,6 +53,7 @@ minetest.override_item("flowers:mushroom_brown", {
 		"nextgen_fungi_mushroom_brown.png",
 		"nextgen_fungi_mushroom_brown.png"
 	},
+	use_texture_alpha = "clip",
 	inventory_image = "nextgen_fungi_mushroom_brown.png",
 	drawtype = "nodebox",
 	paramtype = "light",


### PR DESCRIPTION
Not setting this field generate warnings client side.
WARNING[Main]: Texture "nextgen_fungi_mushroom_red_top.png" of flowers:mushroom_red has transparency, assuming use_texture_alpha = "clip".
WARNING[Main]: Texture "nextgen_fungi_mushroom_brown_top.png" of flowers:mushroom_brown has transparency, assuming use_texture_alpha = "clip".